### PR TITLE
feat: Fail cleanup-workspace if not macOS

### DIFF
--- a/.github/actions/cleanup-workspace/action.yml
+++ b/.github/actions/cleanup-workspace/action.yml
@@ -15,9 +15,9 @@ runs:
         fi
         find "$WORKSPACE" -depth 1 | xargs rm -rfv
 
-    - name: Fail if not MacOS
+    - name: Fail if not macOS
       if: ${{ runner.os != 'macOS' }}
       shell: bash
       run: |
-        echo "This action only supports MacOS."
+        echo "This action only supports macOS."
         exit 1


### PR DESCRIPTION
We do not need `cleanup-workspace` for other platforms, but let's make it explicitly fail with a good reason if called improperly.

Resolves #10 