### PR TITLE
Remove old fmt v11 to be able to run ccache

### DIFF
--- a/.github/actions/prepare-runner/action.yml
+++ b/.github/actions/prepare-runner/action.yml
@@ -29,6 +29,19 @@ runs:
           ninja \
           python@3.14
 
+    - name: Remove old fmt using Homebrew (macOS)
+      if: ${{ runner.os == 'macOS' }}
+      shell: bash
+      run: |
+        brew unlink fmt
+        brew cleanup
+        brew link fmt
+
+    - name: List software installed using Homebrew (macOS)
+      if: ${{ runner.os == 'macOS' }}
+      shell: bash
+      run: brew list --version
+
     - name: Install build tools using pip (macOS)
       if: ${{ runner.os == 'macOS' }}
       shell: bash

--- a/.github/workflows/test-prepare-runner.yml
+++ b/.github/workflows/test-prepare-runner.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
-      - name: Test prepare-runner action
+      - name: Run prepare-runner action
         uses: ./.github/actions/prepare-runner
         with:
           disable_ccache: true
@@ -43,8 +43,11 @@ jobs:
           fi
           echo "CCACHE_DISABLE is correctly set to 1"
 
-      - name: Verify build tools are installed
+      - name: Verify build tools are able to run
         shell: bash
         run: |
           cmake --version
           conan --version
+          if [ "${{ runner.os }}" != "Windows" ]; then
+            ccache --version
+          fi


### PR DESCRIPTION
Recently new major of `fmtlib` has been released: https://github.com/fmtlib/fmt/releases
`ccache` uses it and recently new revision has been built to start using it: https://github.com/Homebrew/homebrew-core/commit/4c00876d448f8fe951e3079decca4e1996fcff80

Unfortunately, on our macOS runners, we ended up with both fmt 11 and 12 being installed, and 11 being linked.
And when `ccache` was run, it tried to use fmt 12, but was searching only the dir for fmt 11.

The solution for this problem is to unlink fmt, run `brew cleanup` (which deletes old versions), and then link again (which will link fmt 12).