### PR TITLE
Add AWS CLI to prepare-runner action

### DIFF
--- a/.github/actions/prepare-runner/action.yml
+++ b/.github/actions/prepare-runner/action.yml
@@ -63,8 +63,9 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       shell: bash
       run: |
-        pip install awscli==1.43.0 \
-                    conan==2.22.1
+        pip install \
+          awscli==1.43.0 \
+          conan==2.22.1
 
     - name: Install Rust (Windows)
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/test-prepare-runner.yml
+++ b/.github/workflows/test-prepare-runner.yml
@@ -25,7 +25,7 @@ jobs:
           - os: heavy
             container: '{ "image": "ghcr.io/xrplf/ci/debian-trixie:gcc-15" }'
           - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/ci/debian-trixie:gcc-15" }'
+            container: '{ "image": "ghcr.io/xrplf/ci/rhel-10:clang-any" }'
           - os: macos15
           - os: windows
 


### PR DESCRIPTION
This change will allow us to upload artifacts to S3 to work around storage limitations in certain repositories.