### PR TITLE
feat: Implement print-env action

### DIFF
--- a/.github/workflows/test-print-env.yml
+++ b/.github/workflows/test-print-env.yml
@@ -1,0 +1,45 @@
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/test-print-env.yml"
+      - "print-env/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/test-print-env.yml"
+      - "print-env/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  test-print-env:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: heavy
+            container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
+          - os: heavy-arm64
+            container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
+          - os: heavy
+            container: '{ "image": "ghcr.io/xrplf/ci/debian-trixie:gcc-15" }'
+          - os: heavy-arm64
+            container: '{ "image": "ghcr.io/xrplf/ci/rhel-10:clang-any" }'
+          - os: macos15
+          - os: windows
+
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container != '' && fromJson(matrix.container) || null }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare runner
+        uses: ./prepare-runner
+        with:
+          enable_ccache: false
+
+      - name: Run print-env action
+        uses: ./print-env

--- a/print-env/action.yml
+++ b/print-env/action.yml
@@ -1,0 +1,43 @@
+name: Print build environment
+description: "Print environment and some tooling versions"
+
+runs:
+  using: composite
+  steps:
+    - name: Check configuration (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      run: |
+        echo 'Checking environment variables.'
+        set
+
+    - name: Check configuration (Linux and macOS)
+      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+      shell: bash
+      run: |
+        echo 'Checking path.'
+        echo ${PATH} | tr ':' '\n'
+
+        echo 'Checking environment variables.'
+        env | sort
+
+        echo 'Checking compiler version.'
+        ${{ runner.os == 'Linux' && '${CC}' || 'clang' }} --version
+
+        echo 'Checking Ninja version.'
+        ninja --version
+
+        echo 'Checking nproc version.'
+        nproc --version
+
+    - name: Check configuration (all)
+      shell: bash
+      run: |
+        echo 'Checking Ccache version.'
+        ccache --version
+
+        echo 'Checking CMake version.'
+        cmake --version
+
+        echo 'Checking Conan version.'
+        conan --version

--- a/print-env/action.yml
+++ b/print-env/action.yml
@@ -21,9 +21,6 @@ runs:
         echo 'Checking environment variables.'
         env | sort
 
-        echo 'Checking compiler version.'
-        ${{ runner.os == 'Linux' && '${CC}' || 'clang' }} --version
-
         echo 'Checking Ninja version.'
         ninja --version
 


### PR DESCRIPTION
This is the same as https://github.com/XRPLF/rippled/blob/develop/.github/actions/print-env/action.yml except for compiler printing.
It works differently for clio, so we can't have it here.
I think it's a reasonable price to pay to have a common action.
When we unify how we build our images (compiler and tools in them as well) and conan profiles, this can be added back (but I doubt it's needed)