### PR TITLE
feat: Add a workflow to determine clang tidy file changes

### DIFF
--- a/.github/workflows/determine-tidy-files.yml
+++ b/.github/workflows/determine-tidy-files.yml
@@ -1,0 +1,45 @@
+name: Determine clang-tidy files
+
+on:
+  workflow_call:
+    outputs:
+      clang_tidy_config_changed:
+        value: ${{ jobs.determine-tidy-files.outputs.clang_tidy_config_changed }}
+      any_cpp_changed:
+        value: ${{ jobs.determine-tidy-files.outputs.any_cpp_changed }}
+      all_changed_files:
+        value: ${{ jobs.determine-tidy-files.outputs.all_changed_files }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  determine-tidy-files:
+    name: Determine files to check
+    runs-on: ubuntu-latest
+    outputs:
+      clang_tidy_config_changed: ${{ steps.changed_clang_tidy_config.outputs.any_changed }}
+      any_cpp_changed: ${{ steps.changed_cpp_files.outputs.any_changed }}
+      all_changed_files: ${{ steps.changed_cpp_files.outputs.all_changed_files }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get changed C++ files
+        id: changed_cpp_files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: |
+            **/*.cpp
+            **/*.h
+            **/*.hpp
+            **/*.ipp
+          separator: " "
+
+      - name: Get changed clang-tidy configuration
+        id: changed_clang_tidy_config
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: |
+            .clang-tidy

--- a/.github/workflows/determine-tidy-files.yml
+++ b/.github/workflows/determine-tidy-files.yml
@@ -5,10 +5,8 @@ on:
     outputs:
       clang_tidy_config_changed:
         value: ${{ jobs.determine-tidy-files.outputs.clang_tidy_config_changed }}
-      any_cpp_changed:
-        value: ${{ jobs.determine-tidy-files.outputs.any_cpp_changed }}
-      all_changed_files:
-        value: ${{ jobs.determine-tidy-files.outputs.all_changed_files }}
+      cpp_changed_files:
+        value: ${{ jobs.determine-tidy-files.outputs.cpp_changed_files }}
 
 defaults:
   run:
@@ -20,11 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       clang_tidy_config_changed: ${{ steps.changed_clang_tidy_config.outputs.any_changed }}
-      any_cpp_changed: ${{ steps.changed_cpp_files.outputs.any_changed }}
-      all_changed_files: ${{ steps.changed_cpp_files.outputs.all_changed_files }}
+      cpp_changed_files: ${{ steps.changed_cpp_files.outputs.all_changed_files }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get changed clang-tidy configuration
+        id: changed_clang_tidy_config
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          files: |
+            .clang-tidy
 
       - name: Get changed C++ files
         id: changed_cpp_files
@@ -36,10 +40,3 @@ jobs:
             **/*.hpp
             **/*.ipp
           separator: " "
-
-      - name: Get changed clang-tidy configuration
-        id: changed_clang_tidy_config
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: |
-            .clang-tidy

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Reusable workflows and actions for XRPLF repos
 
 - `check-pr-commits.yml`: Checks the commits in Pull Requests are signed.
 - `check-pr-title.yml`: Checks the title of Pull Requests against a specified pattern.
+- `determine-tidy-files.yml`: Determines which files have been modified in a Pull Request and sets an output variables with the list of those files.
 - `pre-commit.yml`: Runs `pre-commit` checks on code changes.
 - `pre-commit-autoupdate.yml`: Runs `pre-commit autoupdate` to update pre-commit hooks.
 


### PR DESCRIPTION
This allows us to implement a feature of partial clang-tidy run for Clio as well, and then write clang-tidy in a very similar fashion.

I don't think we can test this workflow, but I doubt it will change a lot, so if it works, I think it's ok.