### PR TITLE
feat: Add a workflow to build multi-arch image

### DIFF
--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -1,0 +1,89 @@
+name: Reusable build and merge Docker image (multi-arch)
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: "Full image name without tag (e.g. 'ghcr.io/xrplf/xrpld/nix-ubuntu')"
+        required: true
+        type: string
+      dockerfile:
+        description: "Path to the Dockerfile, relative to the repository root"
+        required: true
+        type: string
+      base_image:
+        description: "Value passed to the Dockerfile as the BASE_IMAGE build arg"
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build ${{ inputs.image_name }}
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    uses: ./.github/workflows/reusable-build-docker-image.yml
+    with:
+      image_name: ${{ inputs.image_name }}
+      dockerfile: ${{ inputs.dockerfile }}
+      base_image: ${{ inputs.base_image }}
+      platform: ${{ matrix.target.platform }}
+      runner: ${{ matrix.target.runner }}
+      push: ${{ github.repository == 'XRPLF/rippled' && github.event_name == 'push' }}
+
+  merge:
+    name: Merge ${{ inputs.image_name }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ inputs.image_name }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifests
+        if: ${{ github.repository == 'XRPLF/rippled' && github.event_name == 'push' }}
+        run: |
+          for tag in $(jq -cr '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON"); do
+              docker buildx imagetools create -t "$tag" "${tag}-amd64" "${tag}-arm64"
+          done
+
+      - name: Inspect image
+        if: ${{ github.repository == 'XRPLF/rippled' && github.event_name == 'push' }}
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_VERSION}"

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -15,6 +15,10 @@ on:
         description: "Value passed to the Dockerfile as the BASE_IMAGE build arg"
         required: true
         type: string
+      push:
+        description: "Whether to push the image to GHCR"
+        required: true
+        type: boolean
 
 defaults:
   run:
@@ -43,7 +47,7 @@ jobs:
       base_image: ${{ inputs.base_image }}
       platform: ${{ matrix.target.platform }}
       runner: ${{ matrix.target.runner }}
-      push: ${{ github.repository == 'XRPLF/rippled' && github.event_name == 'push' }}
+      push: ${{ inputs.push }}
 
   merge:
     name: Merge ${{ inputs.image_name }}
@@ -74,14 +78,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create multi-arch manifests
-        if: ${{ github.repository == 'XRPLF/rippled' && github.event_name == 'push' }}
+        if: ${{ inputs.push }}
         run: |
           for tag in $(jq -cr '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON"); do
               docker buildx imagetools create -t "$tag" "${tag}-amd64" "${tag}-arm64"
           done
 
       - name: Inspect image
-        if: ${{ github.repository == 'XRPLF/rippled' && github.event_name == 'push' }}
+        if: ${{ inputs.push }}
         env:
           IMAGE_NAME: ${{ inputs.image_name }}
           IMAGE_VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/reusable-build-docker-image.yml
+++ b/.github/workflows/reusable-build-docker-image.yml
@@ -1,0 +1,89 @@
+# Build a single-platform Docker image. On push, the image is pushed to
+# GHCR with arch-suffixed tags (e.g. `:latest-amd64`, `:sha-abc-amd64`)
+# so the calling workflow can stitch per-arch builds into a multi-arch
+# manifest without needing to pass digests around.
+name: Reusable build Docker image (single platform)
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: "Full image name without tag (e.g. 'ghcr.io/xrplf/xrpld/nix-ubuntu')"
+        required: true
+        type: string
+      dockerfile:
+        description: "Path to the Dockerfile, relative to the repository root"
+        required: true
+        type: string
+      base_image:
+        description: "Value passed to the Dockerfile as the BASE_IMAGE build arg"
+        required: true
+        type: string
+      platform:
+        description: "Docker platform string, e.g. linux/amd64"
+        required: true
+        type: string
+      runner:
+        description: "GitHub Actions runner label to build on"
+        required: true
+        type: string
+      push:
+        description: "Whether to push the image to GHCR"
+        required: true
+        type: boolean
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build ${{ inputs.platform }}
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Determine arch
+        id: vars
+        env:
+          PLATFORM: ${{ inputs.platform }}
+        run: |
+          echo "arch=${PLATFORM##*/}" >>$GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GitHub Container Registry
+        if: inputs.push
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ inputs.image_name }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest
+          flavor: |
+            suffix=-${{ steps.vars.outputs.arch }},onlatest=true
+
+      - name: Build and push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platform }}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: BASE_IMAGE=${{ inputs.base_image }}

--- a/.github/workflows/test-build-multiarch-image.yml
+++ b/.github/workflows/test-build-multiarch-image.yml
@@ -39,7 +39,7 @@ jobs:
             base_image: debian:bookworm
           - name: rhel
             base_image: registry.access.redhat.com/ubi9/ubi:latest
-    uses: ./.github/workflows/reusable-build-merge-docker-images.yml
+    uses: ./.github/workflows/build-multiarch-image.yml
     with:
       image_name: ghcr.io/xrplf/actions/actions-test-${{ matrix.distro.name }}
       dockerfile: test/image/Dockerfile

--- a/.github/workflows/test-build-multiarch-image.yml
+++ b/.github/workflows/test-build-multiarch-image.yml
@@ -16,6 +16,8 @@ on:
       - ".github/workflows/test-build-multiarch-image.yml"
       - "test/image/**"
   workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || github.ref }}
@@ -44,3 +46,4 @@ jobs:
       image_name: ghcr.io/xrplf/actions/actions-test-${{ matrix.distro.name }}
       dockerfile: test/image/Dockerfile
       base_image: ${{ matrix.distro.base_image }}
+      push: ${{ github.repository == 'XRPLF/actions' && github.event_name != 'pull_request' }}

--- a/.github/workflows/test-build-multiarch-image.yml
+++ b/.github/workflows/test-build-multiarch-image.yml
@@ -1,0 +1,46 @@
+name: Build actions-test Docker images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/build-multiarch-image.yml"
+      - ".github/workflows/reusable-build-docker-image.yml"
+      - ".github/workflows/test-build-multiarch-image.yml"
+      - "test/image/**"
+  pull_request:
+    paths:
+      - ".github/workflows/build-multiarch-image.yml"
+      - ".github/workflows/reusable-build-docker-image.yml"
+      - ".github/workflows/test-build-multiarch-image.yml"
+      - "test/image/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-merge:
+    name: Build and push test multiarch actions-test image
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - name: debian
+            base_image: debian:bookworm
+          - name: rhel
+            base_image: registry.access.redhat.com/ubi9/ubi:latest
+    uses: ./.github/workflows/reusable-build-merge-docker-images.yml
+    with:
+      image_name: ghcr.io/xrplf/actions/actions-test-${{ matrix.distro.name }}
+      dockerfile: test/image/Dockerfile
+      base_image: ${{ matrix.distro.base_image }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Reusable workflows and actions for XRPLF repos
 
 ## Available Reusable Workflows
 
+- `build-multiarch-image.yml`: Builds a multi-architecture Docker image and pushes it to a container registry.
 - `check-pr-commits.yml`: Checks the commits in Pull Requests are signed.
 - `check-pr-title.yml`: Checks the title of Pull Requests against a specified pattern.
 - `determine-tidy-files.yml`: Determines which files have been modified in a Pull Request and sets an output variables with the list of those files.

--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -1,0 +1,7 @@
+ARG BASE_IMAGE=ubuntu:20.04
+FROM ${BASE_IMAGE}
+
+# Should copy from repo root
+COPY README.md /README.md
+
+RUN echo "Wow, it works!"


### PR DESCRIPTION
This seems like a good thing to have, also decreases mental load on workflows in ripppled and possibly clio.