### PR TITLE
fix: Trust AWS Homebrew tap

### DIFF
--- a/prepare-runner/action.yml
+++ b/prepare-runner/action.yml
@@ -17,10 +17,10 @@ runs:
           cmake \
           conan
 
-    - name: Trust Amazon SSM Agent (macOS)
+    - name: Trust AWS Homebrew tap (macOS)
       if: ${{ runner.os == 'macOS' }}
       shell: bash
-      run: brew trust --cask aws/aws/amazon-ssm-agent
+      run: brew trust aws/aws
 
     - name: Install build tools using Homebrew (macOS)
       if: ${{ runner.os == 'macOS' }}

--- a/prepare-runner/action.yml
+++ b/prepare-runner/action.yml
@@ -17,6 +17,11 @@ runs:
           cmake \
           conan
 
+    - name: Trust Amazon SSM Agent (macOS)
+      if: ${{ runner.os == 'macOS' }}
+      shell: bash
+      run: brew trust --cask aws/aws/amazon-ssm-agent
+
     - name: Install build tools using Homebrew (macOS)
       if: ${{ runner.os == 'macOS' }}
       shell: bash


### PR DESCRIPTION
Homebrew is changing policy to not trust taps, so we have to explicitly trust it: https://github.com/XRPLF/rippled/actions/runs/27136106635/job/80088985135?pr=7417#step:4:120

CI failure on Clio images is unrelated, it's due to bad images without arm being pushed