### PR TITLE
test: Test only nix-based images

### DIFF
--- a/.github/workflows/test-create-issue.yml
+++ b/.github/workflows/test-create-issue.yml
@@ -11,7 +11,7 @@ jobs:
   test-create-issue:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/xrplf/xrpld/nixos-ubuntu:latest
+      image: ghcr.io/xrplf/xrpld/nix-ubuntu:latest
 
     permissions:
       contents: read

--- a/.github/workflows/test-create-issue.yml
+++ b/.github/workflows/test-create-issue.yml
@@ -11,7 +11,7 @@ jobs:
   test-create-issue:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/xrplf/clio-ci:latest
+      image: ghcr.io/xrplf/xrpld/nixos-ubuntu:latest
 
     permissions:
       contents: read

--- a/.github/workflows/test-get-nproc.yml
+++ b/.github/workflows/test-get-nproc.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         include:
           - os: heavy
-            container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
           - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
           - os: macos15
           - os: windows
 

--- a/.github/workflows/test-get-nproc.yml
+++ b/.github/workflows/test-get-nproc.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         include:
           - os: heavy
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:latest" }'
           - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:latest" }'
           - os: macos15
           - os: windows
 

--- a/.github/workflows/test-prepare-runner.yml
+++ b/.github/workflows/test-prepare-runner.yml
@@ -19,13 +19,9 @@ jobs:
       matrix:
         include:
           - os: heavy
-            container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
           - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
-          - os: heavy
-            container: '{ "image": "ghcr.io/xrplf/ci/debian-trixie:gcc-15" }'
-          - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/ci/rhel-10:clang-any" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
           - os: macos15
           - os: windows
 
@@ -56,10 +52,7 @@ jobs:
           cmake --version
           conan --version
           ccache --version
-          # Rust is not installed in the Clio CI image.
-          if [[ ! "${{ matrix.container }}" =~ ghcr.io/xrplf/clio-ci ]]; then
-              rustc -Vv
-          fi
+          rustc -Vv
 
           if [[ "${{ matrix.os }}" == "macos15" ]]; then
               colima --version

--- a/.github/workflows/test-prepare-runner.yml
+++ b/.github/workflows/test-prepare-runner.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         include:
           - os: heavy
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:latest" }'
           - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:latest" }'
           - os: macos15
           - os: windows
 

--- a/.github/workflows/test-prepare-runner.yml
+++ b/.github/workflows/test-prepare-runner.yml
@@ -52,7 +52,6 @@ jobs:
           cmake --version
           conan --version
           ccache --version
-          rustc -Vv
 
           if [[ "${{ matrix.os }}" == "macos15" ]]; then
               colima --version

--- a/.github/workflows/test-print-build-env.yml
+++ b/.github/workflows/test-print-build-env.yml
@@ -19,13 +19,9 @@ jobs:
       matrix:
         include:
           - os: heavy
-            container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
           - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/clio-ci:latest" }'
-          - os: heavy
-            container: '{ "image": "ghcr.io/xrplf/ci/debian-trixie:gcc-15" }'
-          - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/ci/rhel-10:clang-any" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
           - os: macos15
           - os: windows
 

--- a/.github/workflows/test-print-build-env.yml
+++ b/.github/workflows/test-print-build-env.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         include:
           - os: heavy
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:latest" }'
           - os: heavy-arm64
-            container: '{ "image": "ghcr.io/xrplf/xrpld/nixos-ubuntu:latest" }'
+            container: '{ "image": "ghcr.io/xrplf/xrpld/nix-ubuntu:latest" }'
           - os: macos15
           - os: windows
 


### PR DESCRIPTION
We now use nix-based images everywhere except pre-commit, so we should test them